### PR TITLE
add streaming reader to utils pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.13
 require (
 	github.com/go-delve/delve v1.4.0 // indirect
 	github.com/operator-framework/operator-sdk v0.15.2
+	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -597,6 +597,7 @@ github.com/sirupsen/logrus v0.0.0-20180523074243-ea8897e79973/go.mod h1:pMByvHTf
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/makefile
+++ b/makefile
@@ -31,7 +31,7 @@ operator-crds:
 
 operator-todo: .id operator-sdk
 	# TODO: move operator-sdk into chart
-	OPERATOR_NAME=clusterop .bin/operator-sdk-$(OPERATOR_SDK_VERSION) run --local --namespace `cat .id`
+	OPERATOR_NAME=clusterop .bin/operator-sdk-$(OPERATOR_SDK_VERSION) run --local --namespace `cat .id` --operator-flags='--zap-devel'
 
 operator-debug: .id operator-sdk
 	# TODO: move operator-sdk into chart

--- a/utils/cmd.go
+++ b/utils/cmd.go
@@ -2,8 +2,15 @@ package utils
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func CopyBufferContentsToFile(srcBuff []byte, destFile string) (err error) {
@@ -57,4 +64,103 @@ func RunCmd(cmdString string) (*bytes.Buffer, error) {
 	}
 
 	return &out, nil
+}
+
+type Cmd struct {
+	*exec.Cmd
+	entry     *logrus.Entry
+	cmdString []string
+	m         *multiCloser
+}
+
+func New(ctx context.Context, entry *logrus.Entry, command string, arg ...string) *Cmd {
+	if entry == nil {
+		entry = defaultEntry
+	}
+	return &Cmd{
+		Cmd:       exec.Command(command, arg...),
+		cmdString: append([]string{command}, arg...),
+		entry:     entry,
+	}
+}
+
+func (c *Cmd) Start() error {
+	_, err := c.startAndPipe()
+	return err
+}
+
+func (c *Cmd) error(err error) error {
+	return fmt.Errorf("cmd: %q err: %s", c.cmdString, err)
+}
+
+func (c *Cmd) Wait() error {
+	// Drain stderr first, probably used less
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		pipeToLog(c.entry.WriterLevel(logrus.ErrorLevel), c.m.stderr)
+	}()
+	go func() {
+		defer wg.Done()
+		pipeToLog(c.entry.WriterLevel(logrus.InfoLevel), c.m.stdout)
+	}()
+	wg.Wait()
+	return c.Cmd.Wait()
+}
+
+func pipeToLog(pipe *io.PipeWriter, reader io.ReadCloser) (int, error) {
+	for {
+		n64, err := io.Copy(pipe, reader)
+		n := int(n64)
+		if err != nil {
+			return n, err
+		}
+		if n == 0 {
+			pipe.Close()
+			reader.Close()
+			return n, io.EOF
+		}
+	}
+}
+
+func (c *Cmd) startAndPipe() (*multiCloser, error) {
+	m, err := c.StdoutStderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.m = m
+
+	return m, c.Cmd.Start()
+}
+
+func (c *Cmd) StdoutStderrPipe() (*multiCloser, error) {
+	stdout, err := c.Cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := c.Cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	// TODO: close underlying pipes
+	return &multiCloser{stdout, stderr}, nil
+}
+
+type multiCloser struct {
+	stdout, stderr io.ReadCloser
+}
+
+func (m *multiCloser) Close() error {
+	var err error
+	if errOut := m.stdout.Close(); errOut != nil {
+		err = errors.Wrap(err, errOut.Error())
+	}
+	errErr := m.stderr.Close()
+	if errErr != nil {
+		err = errors.Wrap(err, errErr.Error())
+	}
+
+	return err
 }

--- a/utils/cmd_test.go
+++ b/utils/cmd_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var outErrCmdString = []string{"sh", "-c", "echo out && >&2 echo error"}
+
+func TestStart(t *testing.T) {
+	logger := logrus.StandardLogger()
+	buf := new(bytes.Buffer)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetOutput(buf)
+	c := New(context.TODO(), logrus.NewEntry(logger), outErrCmdString[0], outErrCmdString[1:]...)
+	if err := c.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// https://github.com/sirupsen/logrus/issues/1111
+	time.Sleep(50 * time.Millisecond)
+
+	scanner := bufio.NewScanner(buf)
+	for i := 0; i < 2; i++ {
+
+		scanner.Scan()
+		var jl jsonLog
+		err := json.Unmarshal(scanner.Bytes(), &jl)
+		if err != nil {
+			t.Fatalf("%d %s", i, err)
+		}
+
+		if len(jl.Msg) == 0 || len(jl.Level) == 0 {
+			t.Fatal("json log did not parse")
+		}
+
+		// order is not enforced, check consistency of level and sg
+		if jl.Level == "error" && jl.Msg != "error" {
+			t.Errorf("got: %s wanted: error", jl.Msg)
+		}
+
+		if jl.Level == "info" && jl.Msg != "out" {
+			t.Errorf("got: %s wanted: out", jl.Msg)
+		}
+
+		if err := scanner.Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+}
+
+type jsonLog struct {
+	Level string
+	Msg   string
+}
+
+func TestMultiCloser(t *testing.T) {
+	c := New(context.TODO(), logrus.NewEntry(logrus.StandardLogger()), outErrCmdString[0], outErrCmdString[1:]...)
+	m, err := c.StdoutStderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	bs, err := ioutil.ReadAll(m.stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e := "out"; e != string(bytes.TrimSpace(bs)) {
+		t.Errorf("got: %s wanted: %s", string(bs), e)
+	}
+	bs, err = ioutil.ReadAll(m.stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e := "error"; e != string(bytes.TrimSpace(bs)) {
+		t.Errorf("got: %s wanted: %s", string(bs), e)
+	}
+}

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var defaultEntry = logrus.NewEntry(logrus.StandardLogger())
+
+// log2LogrusWriter exploits the documented fact that the standard
+// log pkg sends each log entry as a single io.Writer.Write call:
+// https://golang.org/pkg/log/#Logger
+type log2LogrusWriter struct {
+	entry *logrus.Entry
+}
+
+func (w *log2LogrusWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	if n > 0 && b[n-1] == '\n' {
+		b = b[:n-1]
+	}
+	w.entry.Info(string(b))
+	return n, nil
+}


### PR DESCRIPTION
DEMO

cmd emits streaming logs to the logrus instance passed to it.
```
ERRO[0029] I0312 14:46:09.537945   31819 create_cluster.go:1568] Using SSH public key: kops.pub
ERRO[0029] I0312 14:46:09.972638   31819 create_cluster.go:562] Inferred --cloud=aws from zone "us-east-2a"
ERRO[0029]
ERRO[0029] Bastion supports --topology='private' only.
```

This insane thing zap emits when passing it the command error 'exit status 1'
```
2020-03-12T14:49:10.978-0500    ERROR   controller-runtime.controller   Reconciler error {"controller": "cluster-controller", "request": "dwells/example-cluster", "error": "exit status 1"}
github.com/go-logr/zapr.(*zapLogger).Error
        /home/drew/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/drew/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:258
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /home/drew/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:232
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
        /home/drew/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:211
....
```