### PR TITLE
update operator to use kops manifests

### DIFF
--- a/deploy/cluster-operator/crds/cluster-operator.infobloxopen.github.com_clusters_crd.yaml
+++ b/deploy/cluster-operator/crds/cluster-operator.infobloxopen.github.com_clusters_crd.yaml
@@ -32,10 +32,14 @@ spec:
         metadata:
           type: object
         spec:
-          description: ClusterSpec defines the desired state of Cluster
-          type: object
+          description: ClusterSpec defines the desired state of Cluster 
+          properties:
+            name:
+              type: string
+            config: 
+              type: string
         status:
-          description: ClusterStatus defines the observed state of Cluster
+          description: ClusterStatus defines the observed state of Cluster 
           type: object
       type: object
   version: v1alpha1

--- a/deploy/cluster.yaml.in
+++ b/deploy/cluster.yaml.in
@@ -5,13 +5,103 @@ metadata:
   namespace: {{ .Name }}
 spec:
   name: {{ .Name }}
-  kops_config:
-    master_count: 1
-    master_ec2: t2.micro
-    vpc: vpc-0a75b33895655b46a
-    worker_count: 2
-    worker_ec2: t2.micro
-    zones:
-    - us-east-2a
-    - us-east-2b
----
+  config: |
+    apiVersion: kops.k8s.io/v1alpha2
+    kind: Cluster
+    metadata:
+      name: {{ .Name }}.soheil.belamaric.com
+    spec:
+      api:
+        dns: {}
+      authorization:
+        rbac: {}
+      channel: stable
+      cloudProvider: aws
+      configBase: s3://kops.state.seizadi.infoblox.com/{{ .Name }}.soheil.belamaric.com
+      etcdClusters:
+      - cpuRequest: 200m
+        etcdMembers:
+        - instanceGroup: master-us-east-2a
+          name: a
+        memoryRequest: 100Mi
+        name: main
+      - cpuRequest: 100m
+        etcdMembers:
+        - instanceGroup: master-us-east-2a
+          name: a
+        memoryRequest: 100Mi
+        name: events
+      iam:
+        allowContainerRegistry: true
+        legacy: false
+      kubelet:
+        anonymousAuth: false
+      kubernetesApiAccess:
+      - 0.0.0.0/0
+      kubernetesVersion: 1.16.7
+      masterPublicName: api.{{ .Name }}.soheil.belamaric.com
+      networkCIDR: 172.17.16.0/21
+      networkID: vpc-0a75b33895655b46a
+      networking:
+        kubenet: {}
+      nonMasqueradeCIDR: 100.64.0.0/10
+      sshAccess:
+      - 0.0.0.0/0
+      subnets:
+      - cidr: 172.17.17.0/24
+        name: us-east-2a
+        type: Public
+        zone: us-east-2a
+      - cidr: 172.17.18.0/24
+        name: us-east-2b
+        type: Public
+        zone: us-east-2b
+      topology:
+        dns:
+          type: Public
+        masters: public
+        nodes: public
+    ---
+    apiVersion: kops.k8s.io/v1alpha2
+    kind: InstanceGroup
+    metadata:
+      labels:
+        kops.k8s.io/cluster: {{ .Name }}.soheil.belamaric.com
+      name: master-us-east-2a
+    spec:
+      image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+      machineType: t2.micro
+      maxSize: 1
+      minSize: 1
+      nodeLabels:
+        kops.k8s.io/instancegroup: master-us-east-2a
+      role: Master
+      subnets:
+      - us-east-2a
+    ---
+    apiVersion: kops.k8s.io/v1alpha2
+    kind: InstanceGroup
+    metadata:
+      labels:
+        kops.k8s.io/cluster: {{ .Name }}.soheil.belamaric.com
+      name: nodes
+    spec:
+      image: kope.io/k8s-1.16-debian-stretch-amd64-hvm-ebs-2020-01-17
+      machineType: t2.micro
+      maxSize: 2
+      minSize: 2
+      nodeLabels:
+        kops.k8s.io/instancegroup: nodes
+      role: Node
+      subnets:
+      - us-east-2a
+      - us-east-2b
+    ---
+    apiVersion: kops/v1alpha2
+    kind: SSHCredential
+    metadata:
+      labels:
+        kops.k8s.io/cluster: {{ .Name }}.soheil.belamaric.com
+    spec:
+      publicKey: "{{ .sshKey }}"
+

--- a/kops/kops.go
+++ b/kops/kops.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"strings"
-	
+
 	clusteroperatorv1alpha1 "github.com/infobloxopen/cluster-operator/pkg/apis/clusteroperator/v1alpha1"
 	"github.com/infobloxopen/cluster-operator/utils"
 	"gopkg.in/yaml.v2"
@@ -88,28 +87,63 @@ func NewKops() (*KopsCmd, error) {
 //	return utils.New(ctx, nil, kopsCmd, kopsArgs...), nil
 //}
 
-func (k *KopsCmd) CreateCluster(cluster clusteroperatorv1alpha1.KopsConfig) error {
+// No longer needed when using Kops Manifests
+// The flow when using Kops Manifests is always kops replace -> kops update
+// The flow applies for both new and existing clusters
+//func (k *KopsCmd) CreateCluster(cluster clusteroperatorv1alpha1.KopsConfig) error {
+//
+//	pwd, err := os.Getwd()
+//	if err != nil {
+//		return err
+//	}
+//	kopsCmdStr := "/usr/local/bin/" +
+//		"docker run" +
+//		" -v " + pwd + "/ssh:/ssh " +
+//		utils.GetDockerEnvFlags(k.envs) +
+//		" soheileizadi/kops:v1.0" +
+//		" --state=" + cluster.StateStore +
+//		" create cluster" +
+//		" --name=" + cluster.Name +
+//		// FIXME - Should have ssh-key-name
+//		" --ssh-public-key=" + "/ssh/" + k.publicKey +
+//		" --vpc=" + cluster.Vpc +
+//		" --master-count=" + strconv.Itoa(cluster.MasterCount) +
+//		" --master-size=" + cluster.MasterEc2 +
+//		" --node-count=" + strconv.Itoa(cluster.WorkerCount) +
+//		" --node-size=" + cluster.WorkerEc2 +
+//		" --zones=" + strings.Join(cluster.Zones, ",")
+//	err = utils.RunStreamingCmd(kopsCmdStr)
+//	if err != nil {
+//		return err
+//	}
+
+//	return nil
+//}
+
+func (k *KopsCmd) ReplaceCluster(cluster clusteroperatorv1alpha1.ClusterSpec) error {
 
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
+
+	tempConfigFile := "tmp/" + cluster.Name + ".yaml"
+	err = utils.CopyBufferContentsToFile([]byte(cluster.Config), tempConfigFile)
+	if err != nil {
+		return err
+	}
+
 	kopsCmdStr := "/usr/local/bin/" +
 		"docker run" +
 		" -v " + pwd + "/ssh:/ssh " +
+		" -v " + pwd + "/" + tempConfigFile + ":/" + tempConfigFile +
 		utils.GetDockerEnvFlags(k.envs) +
 		" soheileizadi/kops:v1.0" +
-		" --state=" + cluster.StateStore +
-		" create cluster" +
-		" --name=" + cluster.Name +
-		// FIXME - Should have ssh-key-name
-		" --ssh-public-key=" + "/ssh/" + k.publicKey +
-		" --vpc=" + cluster.Vpc +
-		" --master-count=" + strconv.Itoa(cluster.MasterCount) +
-		" --master-size=" + cluster.MasterEc2 +
-		" --node-count=" + strconv.Itoa(cluster.WorkerCount) +
-		" --node-size=" + cluster.WorkerEc2 +
-		" --zones=" + strings.Join(cluster.Zones, ",")
+		" replace cluster" +
+		" -f " + tempConfigFile +
+		" --state=" + cluster.KopsConfig.StateStore +
+		" --force"
+
 	err = utils.RunStreamingCmd(kopsCmdStr)
 	if err != nil {
 		return err
@@ -119,7 +153,6 @@ func (k *KopsCmd) CreateCluster(cluster clusteroperatorv1alpha1.KopsConfig) erro
 }
 
 func (k *KopsCmd) UpdateCluster(cluster clusteroperatorv1alpha1.KopsConfig) error {
-
 	if k.devMode { // Dry-run in Dev Mode and skip Update Cluster
 		return nil
 	}
@@ -133,8 +166,8 @@ func (k *KopsCmd) UpdateCluster(cluster clusteroperatorv1alpha1.KopsConfig) erro
 		" --name=" + cluster.Name +
 		// FIXME - Add in when we switch to kops config
 		// https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md#use-existing-aws-instance-profiles
-		// " --lifecycle-overrides IAMRole=ExistsAndWarnIfChanges," +
-		// "IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges" +
+		" --lifecycle-overrides IAMRole=ExistsAndWarnIfChanges," +
+		" IAMRolePolicy=ExistsAndWarnIfChanges,IAMInstanceProfileRole=ExistsAndWarnIfChanges" +
 		" --yes"
 
 	err := utils.RunStreamingCmd(kopsCmd)
@@ -233,7 +266,7 @@ func (k *KopsCmd) ValidateCluster(cluster clusteroperatorv1alpha1.KopsConfig) (c
 			Nodes: []clusteroperatorv1alpha1.KopsNode{
 				{
 					Name:     "ip-172-17-17-143.compute.internal",
-					Zone:     cluster.Zones[0],
+					Zone:     "us-east-2a",
 					Role:     "Master",
 					Hostname: "ip-172-17-17-143.compute.internal",
 					Status:   "True",

--- a/kops/kops.go
+++ b/kops/kops.go
@@ -127,8 +127,8 @@ func (k *KopsCmd) ReplaceCluster(cluster clusteroperatorv1alpha1.ClusterSpec) er
 		return err
 	}
 
-	tempConfigFile := "tmp/" + cluster.Name + ".yaml"
-	err = utils.CopyBufferContentsToFile([]byte(cluster.Config), tempConfigFile)
+	tempConfigFile := cluster.Name + ".yaml"
+	err = utils.CopyBufferContentsToTempFile([]byte(cluster.Config), tempConfigFile)
 	if err != nil {
 		return err
 	}
@@ -136,11 +136,11 @@ func (k *KopsCmd) ReplaceCluster(cluster clusteroperatorv1alpha1.ClusterSpec) er
 	kopsCmdStr := "/usr/local/bin/" +
 		"docker run" +
 		" -v " + pwd + "/ssh:/ssh " +
-		" -v " + pwd + "/" + tempConfigFile + ":/" + tempConfigFile +
+		" -v " + pwd + "/tmp/" + tempConfigFile + ":/tmp/" + tempConfigFile +
 		utils.GetDockerEnvFlags(k.envs) +
 		" soheileizadi/kops:v1.0" +
 		" replace cluster" +
-		" -f " + tempConfigFile +
+		" -f /tmp/" + tempConfigFile +
 		" --state=" + cluster.KopsConfig.StateStore +
 		" --force"
 

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ OPERATOR_SDK_VERSION := v0.15.2
 operator-sdk: .bin/operator-sdk-$(OPERATOR_SDK_VERSION)
 
 deploy/cluster.yaml: .id deploy/cluster.yaml.in
-	sed "s/{{ .Name }}/`cat .id`/g" deploy/cluster.yaml.in > $@
+	sed "s/{{ .Name }}/`cat .id`/g; s#{{ .sshKey }}#`cat ./ssh/kops.pub`#g" deploy/cluster.yaml.in > $@
 
 operator-chart:
 	helm upgrade -i `cat .id`-cluster-operator --namespace `cat .id` \

--- a/pkg/apis/clusteroperator/v1alpha1/cluster_types.go
+++ b/pkg/apis/clusteroperator/v1alpha1/cluster_types.go
@@ -110,6 +110,8 @@ type ClusterSpec struct {
 	// Cannot be updated.
 	Name string `json:"name,omitempty"`
 	// Kops Cluster Config
+	Config string `json:"config,omitempty"`
+	// Kops Cluster Config
 	KopsConfig KopsConfig `json:"kops_config,omitempty"`
 }
 


### PR DESCRIPTION
Addressing [Issue 3](https://github.com/infobloxopen/cluster-operator/issues/3).

- Update CRD / API to use Kops manifest yaml
- Update state machine to use kops replace instead of kops create to utilize the Kops Manifest
- Update default KopsConfig to provide only Name and StateStore
- Update Cluster.yaml.in to provide a sample CR with the kops manifest for testing
- Update make deploy/Cluster.yaml to also fill in the ssh key with the key provided at ssh/kops.pub

The update also addressed [Issue 8](https://github.com/infobloxopen/cluster-operator/issues/8) as the pattern for both new and updated clusters should be kops replace -> kops update.  Noticed  updating the CR does not reset the phase from DONE, would be a TODO item to finish up that issue.