### PR TITLE
Fix for failing github workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,7 @@ jobs:
         GOPATH: ${{ github.workspace }}
       working-directory: ${{ github.workspace }}/src/github.com/infobloxopen/cluster-operator
       run: |
-        git fetch --depth=100 origin +refs/tags/*:refs/tags/*
+        # git fetch --depth=100 origin +refs/tags/*:refs/tags/*
         # FIXME: setup docker build user for infoblox docker hub
         #echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
         # Setups up Github access with a provided Pat


### PR DESCRIPTION
The gitfetch command for the 'Machine setup' job is producing a non-zero exit code failing the job.

```
~/cluster-operator $ git fetch --depth=100 origin +refs/tags/*:refs/tags/* 
~/cluster-operator $ echo $?
1
```

Commenting the line out to allow the workflow to test code build and unblock current PRs.