### PR TITLE
added the protected flag the CR config blob - verified that it is ref…

### DIFF
--- a/deploy/cluster.yaml.in
+++ b/deploy/cluster.yaml.in
@@ -16,6 +16,8 @@ spec:
       authorization:
         rbac: {}
       channel: stable
+      cloudLabels:
+        Protected: "FALSE"
       cloudProvider: aws
       configBase: s3://kops.state.seizadi.infoblox.com/{{ .Name }}.soheil.belamaric.com
       etcdClusters:


### PR DESCRIPTION
…lected in state store

Not checking in the CRD changes as cluster CR is currently using the config blob and not injecting any default values from CRD  into the spec.